### PR TITLE
remove unneeded unwraps

### DIFF
--- a/src/begin_batch.rs
+++ b/src/begin_batch.rs
@@ -40,13 +40,8 @@ impl Display for BeginBatch {
         } else {
             ""
         };
-        if self.timestamp.is_some() {
-            write!(
-                f,
-                "BEGIN {}BATCH USING TIMESTAMP {} ",
-                modifiers,
-                self.timestamp.unwrap()
-            )
+        if let Some(timestamp) = self.timestamp {
+            write!(f, "BEGIN {}BATCH USING TIMESTAMP {} ", modifiers, timestamp)
         } else {
             write!(f, "BEGIN {}BATCH ", modifiers)
         }

--- a/src/common.rs
+++ b/src/common.rs
@@ -562,12 +562,12 @@ impl Display for PrimaryKey {
             write!(f, "")
         } else if self.partition.len() == 1 {
             if self.clustering.is_empty() {
-                write!(f, "PRIMARY KEY ({})", self.partition.get(0).unwrap())
+                write!(f, "PRIMARY KEY ({})", self.partition[0])
             } else {
                 write!(
                     f,
                     "PRIMARY KEY ({}, {})",
-                    self.partition.get(0).unwrap(),
+                    self.partition[0],
                     self.clustering.join(", ")
                 )
             }
@@ -605,8 +605,8 @@ impl Display for Resource {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Resource::AllFunctions(str) => {
-                if str.is_some() {
-                    write!(f, "ALL FUNCTIONS IN KEYSPACE {}", str.as_ref().unwrap())
+                if let Some(str) = str {
+                    write!(f, "ALL FUNCTIONS IN KEYSPACE {}", str)
                 } else {
                     write!(f, "ALL FUNCTIONS")
                 }
@@ -631,8 +631,8 @@ impl WhereClause {
 
         for relation_element in where_clause {
             if let Operand::Column(key) = &relation_element.obj {
-                if result.contains_key(key) {
-                    result.get_mut(key).unwrap().push(relation_element.clone());
+                if let Some(value) = result.get_mut(key) {
+                    value.push(relation_element.clone());
                 } else {
                     result.insert(key.clone(), vec![relation_element.clone()]);
                 }
@@ -644,17 +644,13 @@ impl WhereClause {
 
     /// get the unordered set of column names for found in the where clause
     pub fn get_column_list(where_clause: Vec<RelationElement>) -> HashSet<String> {
-        let mut result = HashSet::new();
         where_clause
-            .iter()
-            .filter_map(|relation_element| match &relation_element.obj {
+            .into_iter()
+            .filter_map(|relation_element| match relation_element.obj {
                 Operand::Column(name) => Some(name),
                 _ => None,
             })
-            .for_each(|s| {
-                result.insert(s.clone());
-            });
-        result
+            .collect()
     }
 }
 
@@ -691,8 +687,8 @@ impl FQName {
 
 impl Display for FQName {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        if self.keyspace.is_some() {
-            write!(f, "{}.{}", self.keyspace.as_ref().unwrap(), self.name)
+        if let Some(keyspace) = &self.keyspace {
+            write!(f, "{}.{}", keyspace, self.name)
         } else {
             write!(f, "{}", self.name)
         }

--- a/src/create_index.rs
+++ b/src/create_index.rs
@@ -16,8 +16,8 @@ pub struct CreateIndex {
 
 impl Display for CreateIndex {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let name = if self.name.is_some() {
-            format!("{} ", self.name.as_ref().unwrap().as_str())
+        let name = if let Some(name) = &self.name {
+            format!("{} ", name)
         } else {
             "".to_string()
         };

--- a/src/create_keyspace.rs
+++ b/src/create_keyspace.rs
@@ -16,7 +16,7 @@ pub struct CreateKeyspace {
 
 impl Display for CreateKeyspace {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        if self.durable_writes.is_some() {
+        if let Some(durable_writes) = self.durable_writes {
             write!(
                 f,
                 "KEYSPACE {}{} WITH REPLICATION = {{{}}} AND DURABLE_WRITES = {}",
@@ -30,11 +30,7 @@ impl Display for CreateKeyspace {
                     .iter()
                     .map(|(x, y)| format!("{}:{}", x, y))
                     .join(", "),
-                if self.durable_writes.unwrap() {
-                    "TRUE"
-                } else {
-                    "FALSE"
-                }
+                if durable_writes { "TRUE" } else { "FALSE" }
             )
         } else {
             write!(

--- a/src/create_table.rs
+++ b/src/create_table.rs
@@ -20,8 +20,8 @@ pub struct CreateTable {
 impl Display for CreateTable {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut v: Vec<String> = self.columns.iter().map(|x| x.to_string()).collect();
-        if self.key.is_some() {
-            v.push(self.key.as_ref().unwrap().to_string());
+        if let Some(key) = &self.key {
+            v.push(key.to_string());
         }
         write!(
             f,

--- a/src/create_user.rs
+++ b/src/create_user.rs
@@ -19,9 +19,9 @@ impl Display for CreateUser {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut with = String::new();
 
-        if self.password.is_some() {
+        if let Some(password) = &self.password {
             with.push_str(" PASSWORD ");
-            with.push_str(self.password.as_ref().unwrap().as_str());
+            with.push_str(password);
         }
         if self.superuser {
             with.push_str(" SUPERUSER");

--- a/src/list_role.rs
+++ b/src/list_role.rs
@@ -12,9 +12,9 @@ pub struct ListRole {
 impl Display for ListRole {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut s: String = "".to_string();
-        if self.of.is_some() {
+        if let Some(of) = &self.of {
             s = " OF ".to_string();
-            s.push_str(self.of.as_ref().unwrap().as_str());
+            s.push_str(of);
         }
         write!(
             f,

--- a/src/role_common.rs
+++ b/src/role_common.rs
@@ -22,24 +22,17 @@ impl Display for RoleCommon {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut with = vec![];
 
-        if self.password.is_some() {
-            with.push(format!("PASSWORD = {}", self.password.as_ref().unwrap()));
+        if let Some(password) = &self.password {
+            with.push(format!("PASSWORD = {}", password));
         }
-        if self.superuser.is_some() {
+        if let Some(superuser) = self.superuser {
             with.push(format!(
                 "SUPERUSER = {}",
-                if self.superuser.unwrap() {
-                    "TRUE"
-                } else {
-                    "FALSE"
-                }
+                if superuser { "TRUE" } else { "FALSE" }
             ));
         }
-        if self.login.is_some() {
-            with.push(format!(
-                "LOGIN = {}",
-                if self.login.unwrap() { "TRUE" } else { "FALSE" }
-            ));
+        if let Some(login) = self.login {
+            with.push(format!("LOGIN = {}", if login { "TRUE" } else { "FALSE" }));
         }
         if !self.options.is_empty() {
             let mut txt = "OPTIONS = {".to_string();


### PR DESCRIPTION
This removes all the cases of unwrap that are easy to remove.

We should do a full audit of unwraps at some point because there are some clearly dangerous ones, but resolving them was too complicated for this cleanup PR.