### PR TITLE
Remove Operand::Collection

### DIFF
--- a/src/cassandra_ast.rs
+++ b/src/cassandra_ast.rs
@@ -1823,28 +1823,21 @@ impl CassandraParser {
                     value: {
                         // consume the oper
                         cursor.goto_next_sibling();
-                        let mut values = vec![];
-                        let inline_tuple = if cursor.node().kind().eq("(") {
-                            // inline tuple or function_args
+
+                        if cursor.node().kind() == "(" {
                             cursor.goto_next_sibling();
-                            true
-                        } else {
-                            false
-                        };
-                        values.push(CassandraParser::parse_operand(&cursor.node(), source));
+                        }
+                        let mut values =
+                            vec![CassandraParser::parse_operand(&cursor.node(), source)];
                         cursor.goto_next_sibling();
-                        while cursor.node().kind().eq(",") {
+                        while cursor.node().kind() == "," {
                             cursor.goto_next_sibling();
                             values.push(CassandraParser::parse_operand(&cursor.node(), source));
                         }
                         if values.len() > 1 {
-                            if inline_tuple {
-                                Operand::Tuple(values)
-                            } else {
-                                Operand::Collection(values)
-                            }
+                            Operand::Tuple(values)
                         } else {
-                            values[0].clone()
+                            values.remove(0)
                         }
                     },
                 }

--- a/src/cassandra_statement.rs
+++ b/src/cassandra_statement.rs
@@ -401,18 +401,18 @@ mod tests {
 
     // only tests single results
     fn test_parsing(expected: &[&str], statements: &[&str]) {
-        for i in 0..statements.len() {
-            let ast = CassandraAST::new(statements[i]);
+        for (statement, expected) in statements.iter().zip(expected) {
+            let ast = CassandraAST::new(statement);
             assert!(
                 !ast.has_error(),
                 "AST has error\n{}\n{} ",
-                statements[i],
+                statement,
                 ast.tree.root_node().to_sexp()
             );
             let stmt = &ast.statements[0];
             assert!(!stmt.has_error);
             let stmt_str = stmt.statement.to_string();
-            assert_eq!(expected[i], stmt_str);
+            assert_eq!(*expected, stmt_str);
         }
     }
     #[test]
@@ -447,7 +447,7 @@ mod tests {
             "SELECT column FROM table WHERE func(*) = func2(*)",
             "SELECT column FROM table WHERE col IN ( 'literal', 5, func(*), true )",
             "SELECT column FROM table WHERE (col1, col2) IN (( 5, 'stuff'), (6, 'other'));",
-            "SELECT column FROM table WHERE (col1, col2) >= ( 5, 'stuff'), (6, 'other')",
+            "SELECT column FROM table WHERE (col1, col2) >= (( 5, 'stuff'), (6, 'other'))",
             "SELECT column FROM table WHERE col1 CONTAINS 'foo'",
             "SELECT column FROM table WHERE col1 CONTAINS KEY 'foo'",
             "SELECT column FROM table ORDER BY col1",
@@ -488,7 +488,7 @@ mod tests {
             "SELECT column FROM table WHERE func(*) = func2(*)",
             "SELECT column FROM table WHERE col IN ('literal', 5, func(*), true)",
             "SELECT column FROM table WHERE (col1, col2) IN ((5, 'stuff'), (6, 'other'))",
-            "SELECT column FROM table WHERE (col1, col2) >= (5, 'stuff'), (6, 'other')",
+            "SELECT column FROM table WHERE (col1, col2) >= ((5, 'stuff'), (6, 'other'))",
             "SELECT column FROM table WHERE col1 CONTAINS 'foo'",
             "SELECT column FROM table WHERE col1 CONTAINS KEY 'foo'",
             "SELECT column FROM table ORDER BY col1 ASC",

--- a/src/common.rs
+++ b/src/common.rs
@@ -175,8 +175,6 @@ pub enum Operand {
     Param(String),
     /// the `NULL` value.
     Null,
-    /// an arbitrary collection of Operands
-    Collection(Vec<Operand>),
 }
 
 /// this is _NOT_ the same as `Operand::Const(string)`  This conversion encloses the value in
@@ -381,7 +379,6 @@ impl Display for Operand {
                 write!(f, "{}", result)
             }
             Operand::Null => write!(f, "NULL"),
-            Operand::Collection(operands) => write!(f, "{}", operands.iter().join(", ").as_str()),
         }
     }
 }


### PR DESCRIPTION
I'm not entirely sure what this was supposed to be but it doesnt make any sense to me.
This code would have allowed for parsing statements like: `SELECT * FROM foo WHERE bar == 1, 2` where the 1, 2 would end up in a `Operand::Collection(["1", "2"])` which is not valid CQL.

Or at least I cant find any reference of it here https://www.datastax.com/blog/deep-look-cql-where-clause

I thought it might have had something to do with function args but function calls end up parsed entirely within the `Operand::Func` despite it claiming to only contain a name.

