### PR TITLE
Fix documentation and type of Operand::Func

### DIFF
--- a/src/cassandra_ast.rs
+++ b/src/cassandra_ast.rs
@@ -1542,7 +1542,7 @@ impl CassandraParser {
             }
             "assignment_set" => Operand::Set(CassandraParser::parse_assignment_set(node, source)),
             "function_args" => Operand::Tuple(CassandraParser::parse_function_args(node, source)),
-            "function_call" => Operand::Func(CassandraParser::parse_identifier(node, source)),
+            "function_call" => Operand::Func(NodeFuncs::as_string(node, source)),
             _ => {
                 unreachable!("{}", node.kind())
             }
@@ -1877,7 +1877,7 @@ impl CassandraParser {
         let kind = node.kind();
         match kind {
             "column" => Operand::Column(CassandraParser::parse_identifier(&node, source)),
-            "function_call" => Operand::Func(CassandraParser::parse_identifier(&node, source)),
+            "function_call" => Operand::Func(NodeFuncs::as_string(&node, source)),
             "(" => {
                 let mut values: Vec<Operand> = Vec::new();
                 // consume '('

--- a/src/common.rs
+++ b/src/common.rs
@@ -169,8 +169,8 @@ pub enum Operand {
     Tuple(Vec<Operand>),
     /// A column name
     Column(Identifier),
-    /// A function name
-    Func(Identifier),
+    /// A function call e.g. foo(bar)
+    Func(String),
     /// A parameter.  The string will either be '?' or ':name'
     Param(String),
     /// the `NULL` value.
@@ -344,10 +344,10 @@ impl Operand {
 impl Display for Operand {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Operand::Column(id) | Operand::Func(id) => {
+            Operand::Column(id) => {
                 write!(f, "{}", id)
             }
-            Operand::Const(text) | Operand::Param(text) => {
+            Operand::Const(text) | Operand::Param(text) | Operand::Func(text) => {
                 write!(f, "{}", text)
             }
             Operand::Map(entries) => {


### PR DESCRIPTION
We should eventually fully parse the components of the func into an AST but for now this fixes the documentation and stores the data in an appropriate type.