### PR TITLE
remove extract_keyspace and other misc cleanup

### DIFF
--- a/src/cassandra_ast.rs
+++ b/src/cassandra_ast.rs
@@ -1847,9 +1847,7 @@ impl CassandraParser {
 
     // Parse an Operator
     fn parse_operator(cursor: &mut TreeCursor) -> RelationOperator {
-        let node = cursor.node();
-        let kind = node.kind();
-        match kind {
+        match cursor.node().kind() {
             "<" => RelationOperator::LessThan,
             "<=" => RelationOperator::LessThanOrEqual,
             "<>" => RelationOperator::NotEqual,
@@ -1857,8 +1855,7 @@ impl CassandraParser {
             ">=" => RelationOperator::GreaterThanOrEqual,
             ">" => RelationOperator::GreaterThan,
             "IN" => RelationOperator::In,
-
-            _ => {
+            kind => {
                 unreachable!("Unknown operator: {}", kind);
             }
         }

--- a/src/cassandra_statement.rs
+++ b/src/cassandra_statement.rs
@@ -195,47 +195,49 @@ impl CassandraStatement {
 
     pub fn get_keyspace<'a>(&'a self, default: &'a Identifier) -> &'a Identifier {
         match self {
-            CassandraStatement::AlterKeyspace(named) => &named.name,
-            CassandraStatement::AlterMaterializedView(named) => {
-                named.name.extract_keyspace(default)
+            CassandraStatement::AlterKeyspace(x) => &x.name,
+            CassandraStatement::AlterMaterializedView(x) => {
+                x.name.keyspace.as_ref().unwrap_or(default)
             }
             CassandraStatement::AlterRole(_) => default,
-            CassandraStatement::AlterTable(named) => named.name.extract_keyspace(default),
-            CassandraStatement::AlterType(named) => named.name.extract_keyspace(default),
+            CassandraStatement::AlterTable(x) => x.name.keyspace.as_ref().unwrap_or(default),
+            CassandraStatement::AlterType(x) => x.name.keyspace.as_ref().unwrap_or(default),
             CassandraStatement::AlterUser(_) => default,
             CassandraStatement::ApplyBatch => default,
-            CassandraStatement::CreateAggregate(named) => named.name.extract_keyspace(default),
-            CassandraStatement::CreateFunction(named) => named.name.extract_keyspace(default),
-            CassandraStatement::CreateIndex(named) => named.table.extract_keyspace(default),
-            CassandraStatement::CreateKeyspace(named) => &named.name,
-            CassandraStatement::CreateMaterializedView(named) => {
-                named.name.extract_keyspace(default)
+            CassandraStatement::CreateAggregate(x) => x.name.keyspace.as_ref().unwrap_or(default),
+            CassandraStatement::CreateFunction(x) => x.name.keyspace.as_ref().unwrap_or(default),
+            CassandraStatement::CreateIndex(x) => x.table.keyspace.as_ref().unwrap_or(default),
+            CassandraStatement::CreateKeyspace(x) => &x.name,
+            CassandraStatement::CreateMaterializedView(x) => {
+                x.name.keyspace.as_ref().unwrap_or(default)
             }
             CassandraStatement::CreateRole(_) => default,
-            CassandraStatement::CreateTable(named) => named.name.extract_keyspace(default),
-            CassandraStatement::CreateTrigger(named) => named.name.extract_keyspace(default),
-            CassandraStatement::CreateType(named) => named.name.extract_keyspace(default),
+            CassandraStatement::CreateTable(x) => x.name.keyspace.as_ref().unwrap_or(default),
+            CassandraStatement::CreateTrigger(x) => x.name.keyspace.as_ref().unwrap_or(default),
+            CassandraStatement::CreateType(x) => x.name.keyspace.as_ref().unwrap_or(default),
             CassandraStatement::CreateUser(_) => default,
-            CassandraStatement::Delete(named) => named.table_name.extract_keyspace(default),
-            CassandraStatement::DropAggregate(named) => named.name.extract_keyspace(default),
-            CassandraStatement::DropFunction(named) => named.name.extract_keyspace(default),
-            CassandraStatement::DropIndex(named) => named.name.extract_keyspace(default),
-            CassandraStatement::DropKeyspace(named) => &named.name.name,
-            CassandraStatement::DropMaterializedView(named) => named.name.extract_keyspace(default),
+            CassandraStatement::Delete(x) => x.table_name.keyspace.as_ref().unwrap_or(default),
+            CassandraStatement::DropAggregate(x) => x.name.keyspace.as_ref().unwrap_or(default),
+            CassandraStatement::DropFunction(x) => x.name.keyspace.as_ref().unwrap_or(default),
+            CassandraStatement::DropIndex(x) => x.name.keyspace.as_ref().unwrap_or(default),
+            CassandraStatement::DropKeyspace(x) => &x.name.name,
+            CassandraStatement::DropMaterializedView(x) => {
+                x.name.keyspace.as_ref().unwrap_or(default)
+            }
             CassandraStatement::DropRole(_) => default,
-            CassandraStatement::DropTable(named) => named.name.extract_keyspace(default),
-            CassandraStatement::DropTrigger(named) => named.name.extract_keyspace(default),
-            CassandraStatement::DropType(named) => named.name.extract_keyspace(default),
+            CassandraStatement::DropTable(x) => x.name.keyspace.as_ref().unwrap_or(default),
+            CassandraStatement::DropTrigger(x) => x.name.keyspace.as_ref().unwrap_or(default),
+            CassandraStatement::DropType(x) => x.name.keyspace.as_ref().unwrap_or(default),
             CassandraStatement::DropUser(_) => default,
             CassandraStatement::Grant(_) => default,
-            CassandraStatement::Insert(named) => named.table_name.extract_keyspace(default),
+            CassandraStatement::Insert(x) => x.table_name.keyspace.as_ref().unwrap_or(default),
             CassandraStatement::ListPermissions(_) => default,
             CassandraStatement::ListRoles(_) => default,
             CassandraStatement::Revoke(_) => default,
-            CassandraStatement::Select(named) => named.table_name.extract_keyspace(default),
-            CassandraStatement::Truncate(named) => named.extract_keyspace(default),
-            CassandraStatement::Update(named) => named.table_name.extract_keyspace(default),
-            CassandraStatement::Use(named) => named,
+            CassandraStatement::Select(x) => x.table_name.keyspace.as_ref().unwrap_or(default),
+            CassandraStatement::Truncate(name) => name.keyspace.as_ref().unwrap_or(default),
+            CassandraStatement::Update(x) => x.table_name.keyspace.as_ref().unwrap_or(default),
+            CassandraStatement::Use(name) => name,
             CassandraStatement::Unknown(_) => default,
         }
     }

--- a/src/common.rs
+++ b/src/common.rs
@@ -713,6 +713,7 @@ impl FQName {
             FQName::simple(txt)
         }
     }
+
     pub fn simple(name: &str) -> FQName {
         FQName {
             keyspace: None,
@@ -724,15 +725,6 @@ impl FQName {
         FQName {
             keyspace: Some(Identifier::parse(keyspace)),
             name: Identifier::parse(name),
-        }
-    }
-
-    /// extracts the keyspace,  Return default if none
-    pub fn extract_keyspace<'a>(&'a self, default: &'a Identifier) -> &'a Identifier {
-        if let Some(keyspace) = &self.keyspace {
-            keyspace
-        } else {
-            default
         }
     }
 }
@@ -759,8 +751,6 @@ impl From<FQName> for std::string::String {
     }
 }
 
-#[derive(Debug, Clone, Eq, Ord, PartialOrd, Deserialize)]
-
 /// Identifers are either Quoted or Unquoted.
 ///  * Unquoted Identifiers:  are case insensitive
 ///  * Quoted Identifiers: are case sensitive.  double quotes appearing within the quoted string are escaped by doubling (i.e. `"foo""bar" is interpreted as `foo"bar`)
@@ -773,6 +763,7 @@ impl From<FQName> for std::string::String {
 /// It is possible to create an Unquoted identifier with an embedded quote (e.g. `Identifier::Unquoted( "foo\"bar" )`).
 /// *Note* that a quote as the first character in an Unquoted Identifier can cause problems if the Identifier is converted
 /// to a string and then parsed again as the second parse will create a Quoted identifier.
+#[derive(Debug, Clone, Eq, Ord, PartialOrd, Deserialize)]
 pub enum Identifier {
     /// This variant is case sensitive
     /// "fOo""bAr""" is stored as fOo"bAr"


### PR DESCRIPTION
extract_keyspace can be trivally recreated manually with Option methods.
Better to let the user do that as its more clear whats going on than having to inspect the implementation of a helper method.
The one usage in shotover has been replaced like this:
![image](https://user-images.githubusercontent.com/5120858/174228813-ab12cd8c-908c-41b7-a42c-117c3f20f54b.png)
