### PR TITLE
Fix batch type parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-cql"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63dc88db52bfcb5717eeb265142722530a63e315d28c74f5f59d35da0d17b99f"
+checksum = "447825d5fce9738ac880421aa703cf1b45afd4143a79bd4339b781455e3fd2bb"
 dependencies = [
  "cc",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,12 @@ bytes = "1.0.0"
 hex = "0.4.3"
 num = { version = "0.4.0", features = ["serde"] }
 uuid = { version = "1.0.0", features = ["serde"]}
-bigdecimal = {version ="0.3.0", features = ["serde"]}
+bigdecimal = { version ="0.3.0", features = ["serde"] }
 serde = { version = "1.0.111", features = ["derive"] }
 
 # Parsers
 tree-sitter = "0.20.5"
-tree-sitter-cql = "0.1.0"
+tree-sitter-cql = "0.1.1"
 
 [dev-dependencies]
 

--- a/src/begin_batch.rs
+++ b/src/begin_batch.rs
@@ -1,45 +1,28 @@
 use std::fmt::{Display, Formatter};
 
+#[derive(PartialEq, Debug, Clone)]
+pub enum BatchType {
+    Logged,
+    Counter,
+    Unlogged,
+}
+
 /// defines the `BEGIN BATCH` data
-/// NOTE: It is possible to set bot LOGGED and UNLOGGED however this will yield an
-/// unparsable statment.
 #[derive(PartialEq, Debug, Clone)]
 pub struct BeginBatch {
-    /* the logged and unlogged can not be merged into a single statement as one or the other or
-    neither may be selected */
-    /// if true the `LOGGED` option will be displayed.
-    pub logged: bool,
-    /// if true the `UNLOGGED` option will be displayed.
-    pub unlogged: bool,
+    pub ty: BatchType,
     /// the optional timestamp for the `BEGIN BATCH` command
     pub timestamp: Option<u64>,
 }
 
-impl Default for BeginBatch {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl BeginBatch {
-    pub fn new() -> BeginBatch {
-        BeginBatch {
-            logged: false,
-            unlogged: false,
-            timestamp: None,
-        }
-    }
-}
-
 impl Display for BeginBatch {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let modifiers = if self.logged {
-            "LOGGED "
-        } else if self.unlogged {
-            "UNLOGGED "
-        } else {
-            ""
+        let modifiers = match self.ty {
+            BatchType::Logged => "",
+            BatchType::Counter => "COUNTER ",
+            BatchType::Unlogged => "UNLOGGED ",
         };
+
         if let Some(timestamp) = self.timestamp {
             write!(f, "BEGIN {}BATCH USING TIMESTAMP {} ", modifiers, timestamp)
         } else {

--- a/src/cassandra_statement.rs
+++ b/src/cassandra_statement.rs
@@ -507,7 +507,7 @@ mod tests {
     #[test]
     fn test_insert_statements() {
         let stmts = [
-            "BEGIN LOGGED BATCH USING TIMESTAMP 5 INSERT INTO keyspace.table (col1, col2) VALUES ('hello', 5);",
+            "BEGIN COUNTER BATCH USING TIMESTAMP 5 INSERT INTO keyspace.table (col1, col2) VALUES ('hello', 5);",
             "INSERT INTO keyspace.table (col1, col2) VALUES ('hello', 5) IF NOT EXISTS",
             "INSERT INTO keyspace.table (col1, col2) VALUES ('hello', 5) USING TIMESTAMP 3",
             "INSERT INTO table (col1, col2) JSON $$ json code $$",
@@ -518,7 +518,7 @@ mod tests {
             "INSERT INTO keyspace.table (col1, col2) VALUES ('hello', ?) IF NOT EXISTS",
     ];
         let expected = [
-            "BEGIN LOGGED BATCH USING TIMESTAMP 5 INSERT INTO keyspace.table (col1, col2) VALUES ('hello', 5)",
+            "BEGIN COUNTER BATCH USING TIMESTAMP 5 INSERT INTO keyspace.table (col1, col2) VALUES ('hello', 5)",
             "INSERT INTO keyspace.table (col1, col2) VALUES ('hello', 5) IF NOT EXISTS",
             "INSERT INTO keyspace.table (col1, col2) VALUES ('hello', 5) USING TIMESTAMP 3",
             "INSERT INTO table (col1, col2) JSON $$ json code $$",
@@ -544,7 +544,7 @@ mod tests {
             "DELETE column, column3 from keyspace.table WHERE column2='foo' IF column4 = ?",
         ];
         let expected  = [
-            "BEGIN LOGGED BATCH USING TIMESTAMP 5 DELETE column['hello'] FROM table WHERE column2 = 'foo' IF EXISTS",
+            "BEGIN BATCH USING TIMESTAMP 5 DELETE column['hello'] FROM table WHERE column2 = 'foo' IF EXISTS",
             "BEGIN UNLOGGED BATCH DELETE column[6] FROM keyspace.table USING TIMESTAMP 5 WHERE column2 = 'foo' IF column3 = 'stuff'",
             "BEGIN BATCH DELETE column['hello'] FROM keyspace.table WHERE column2 = 'foo'",
             "DELETE FROM table WHERE column2 = 'foo'",
@@ -745,7 +745,7 @@ mod tests {
             "UPDATE foo SET c = 'yo', v = 123 WHERE z = 1",
     ];
         let expected = [
-            "BEGIN LOGGED BATCH USING TIMESTAMP 5 UPDATE keyspace.table SET col1 = 'foo' WHERE col2 = 5",
+            "BEGIN BATCH USING TIMESTAMP 5 UPDATE keyspace.table SET col1 = 'foo' WHERE col2 = 5",
             "UPDATE keyspace.table USING TIMESTAMP 3 SET col1 = 'foo' WHERE col2 = 5",
             "UPDATE keyspace.table SET col1 = 'foo' WHERE col2 = 5 IF EXISTS",
             "UPDATE keyspace.table SET col1 = 'foo' WHERE col2 = 5 IF col3 = 7",


### PR DESCRIPTION
Dependent on https://github.com/shotover/tree-sitter-cql/pull/12

Properly implements batch type parsing as described here: https://docs.datastax.com/en/dse/6.0/cql/cql/cql_reference/cql_commands/cqlBatch.html
Is backwards compatible with the undocumented LOGGED option which seems to appear online in example snippets and in the antlr parser.