### PR TITLE
Add badges to readme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.5"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ description = "A Rust implementation of a CQL3 Parser"
 
 [dependencies]
 itertools = "0.10.1"
-regex = "1"
+regex = "1.5.6"
 bytes = "1.0.0"
 hex = "0.4.3"
 num = { version = "0.4.0", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # CQL3 Parser
 
-This is a full implementation of an Apache Cassandra CQL3 query language parser.
-The goal of this package is to parse CQL3 statements into a structure that can be used in a 
-multi-threaded envrionment.  It uses the tree-sitter-cql3 parser to parse the original query and
-then constructs an editable thread safe representation of the query.
+[![dependency status](https://deps.rs/repo/github/shotover/rust-cql3-parser/status.svg)](https://deps.rs/repo/github/shotover/rust-cql3-parser)
+[![Crates.io](https://img.shields.io/crates/v/cql3_parser.svg)](https://crates.io/crates/cql3-parser)
+[![Released API docs](https://docs.rs/cql3-parser/badge.svg)](https://docs.rs/cql3-parser)
 
+This is a full implementation of an Apache Cassandra CQL3 query language parser.
+The goal of this package is to parse CQL3 statements into a structure that can be used in a
+multi-threaded envrionment. It uses the tree-sitter-cql3 parser to parse the original query and
+then constructs an editable thread safe representation of the query.
 
 ## Common usage
 
@@ -33,23 +36,22 @@ let edited_stmt = stmt.to_string();
 
 The above code changes `SELECT foo FROM myTable` to `Select foo, bar AS baz FROM myTable ORDER BY baz ASC`.
 
-*_NOTE_*: It is possible to create invalid statements.  If in doubt reparse the new statement to verify that it is syntactically correct.
+**NOTE**: It is possible to create invalid statements.  If in doubt reparse the new statement to verify that it is syntactically correct.
 
 ## Package Structure
 
- * The parser is in the `cassandra_ast` module.
- * The Statements are in the `cassandra_statements` module.
- * The data for the statements are found in various modules named for the statement (e.g. `create_table` has the Create Table specific structs).
- * Structures that are common to several packages are found in the `common` module.
- * Many of the `Drop` statements have the same structure, it is in `common_drop`.
- * The statements dealing with Roles (e.g. `Create Role`) utilize the `role_common` module.
+* The parser is in the `cassandra_ast` module.
+* The Statements are in the `cassandra_statements` module.
+* The data for the statements are found in various modules named for the statement (e.g. `create_table` has the Create Table specific structs).
+* Structures that are common to several packages are found in the `common` module.
+* Many of the `Drop` statements have the same structure, it is in `common_drop`.
+* The statements dealing with Roles (e.g. `Create Role`) utilize the `role_common` module.
 
 ## A Note on Errors
 
 When a statement is absolutely unparsable the parser will return a `CassandraStatement::Unknown`
-object.  For example `CassandraAST::new("This is an invalid statement");` yields 
-`CassandraStatement::Unknown("This is an invalid statement")`.  However, if a statement is 
+object.  For example `CassandraAST::new("This is an invalid statement");` yields
+`CassandraStatement::Unknown("This is an invalid statement")`.  However, if a statement is
 partially parsable multiple results are returned.  For example `CassandraAST::new("SELECT * FROM foo WHERE some invalid part");` yields
-`CassandraStatement::Select( select )` where the select is the result of parsing `"SELECT * FROM foo` followed  by 
+`CassandraStatement::Select( select )` where the select is the result of parsing `"SELECT * FROM foo` followed  by
 `CassandraStatement::Unknown("SELECT * FROM foo WHERE some invalid part")`.
-


### PR DESCRIPTION
The main reason I care about this is it makes for a nice shortcut to quickly access the docs/crates.io/deps.rs

regex crate is bumped to 1.5.6, this just enforces a minimum of 1.5.6 to make the deps.rs security check happy.

Also cleaned up some formatting in the readme.