### PR TITLE
Fix drop table

### DIFF
--- a/src/cassandra_ast.rs
+++ b/src/cassandra_ast.rs
@@ -1970,7 +1970,7 @@ impl CassandraParser {
             cursor.goto_next_sibling();
         }
         CommonDrop {
-            name: CassandraParser::parse_dotted_name(&mut cursor, source),
+            name: CassandraParser::parse_table_name(&cursor.node(), source),
             if_exists,
         }
     }


### PR DESCRIPTION
Fixes the failure in https://github.com/shotover/shotover-proxy/pull/804

The new unittest will fail without the implementation change.