### PR TITLE
Bump rust to 1.64

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.60"
+channel = "1.64"
 components = [ "rustfmt", "clippy" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::derive_partial_eq_without_eq)]
+
 pub mod aggregate;
 pub mod alter_column;
 pub mod alter_materialized_view;


### PR DESCRIPTION
We already have the same #[allow(..)] on shotover where we agreed the clippy lint was silly.