### PR TITLE
Release 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cql3-parser"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bigdecimal",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cql3-parser"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Claude <claude.warren@instaclustr.com>"]
 edition = "2021"
 rust-version = "1.56"


### PR DESCRIPTION
only change is https://github.com/shotover/rust-cql3-parser/pull/33 which is non-breaking