### PR TITLE
Release 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cql3-parser"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bigdecimal",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cql3-parser"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Claude <claude.warren@instaclustr.com>"]
 edition = "2021"
 rust-version = "1.56"


### PR DESCRIPTION
The only change since 0.3.1 is https://github.com/shotover/rust-cql3-parser/commit/bde805712e695846a6f6c9c81d057f9c3b0d3e0d which is non-breaking (just adds some new structs/enums)