### PR TITLE
Release cql3-parser 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "cql3-parser"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "bigdecimal",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cql3-parser"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Claude <claude.warren@instaclustr.com>"]
 edition = "2021"
 rust-version = "1.56"


### PR DESCRIPTION
Needs to be a breaking change since https://github.com/shotover/rust-cql3-parser/pull/38 updated bigdecimal, which is exposed in our public API.