### PR TITLE
Release 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "cql3-parser"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bigdecimal",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cql3-parser"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Claude <claude.warren@instaclustr.com>"]
 edition = "2021"
 rust-version = "1.56"


### PR DESCRIPTION
The only change was https://github.com/shotover/rust-cql3-parser/pull/46 which is non-breaking.